### PR TITLE
fix: save() persists a non-positive TTL when the clock ticks over mid-save

### DIFF
--- a/src/Limit.php
+++ b/src/Limit.php
@@ -372,7 +372,7 @@ class Limit
         $successful = $store->set(
             key: $this->getName(),
             value: json_encode($data, JSON_THROW_ON_ERROR),
-            ttl: $this->getRemainingSeconds(),
+            ttl: max($this->getRemainingSeconds(), 1),
         );
 
         if ($successful === false) {

--- a/tests/Unit/LimitStoreTest.php
+++ b/tests/Unit/LimitStoreTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Saloon\RateLimitPlugin\Limit;
 use Saloon\RateLimitPlugin\Stores\MemoryStore;
+use Saloon\RateLimitPlugin\Contracts\RateLimitStore;
 use Saloon\RateLimitPlugin\Exceptions\LimitException;
 use Saloon\RateLimitPlugin\Tests\Fixtures\Connectors\TestConnector;
 
@@ -89,4 +90,36 @@ test('when saving the limit if the expiry time is less than a second away then t
         'timestamp' => $currentTime + 60,
         'hits' => 1,
     ]);
+});
+
+test('the limit is not saved with a non-positive ttl when the clock ticks over mid-save', function () {
+    $store = new class implements RateLimitStore {
+        public ?int $ttl = null;
+
+        public function get(string $key): ?string
+        {
+            return null;
+        }
+
+        public function set(string $key, string $value, int $ttl): bool
+        {
+            $this->ttl = $ttl;
+
+            return true;
+        }
+    };
+
+    $limit = (new class(15) extends Limit {
+        protected int $clockReads = 0;
+
+        // The tick lands between the two reads of the remaining time inside save().
+        protected function getCurrentTimestamp(): int
+        {
+            return parent::getCurrentTimestamp() + ($this->clockReads++ > 0 ? 1 : 0);
+        }
+    })->everySeconds(1)->setPrefix('custom')->name('limit');
+
+    $limit->hit()->save($store);
+
+    expect($store->ttl)->toBe(1);
 });


### PR DESCRIPTION
`Limit::save()` reads `getRemainingSeconds()` twice: once for the reset guard, once for the store TTL. Both sides work in whole seconds, so when the wall clock ticks over between the two reads, the guard sees `1` and the TTL comes out `0`. With `Limit::allow(15)->everySeconds(1)` that boundary is crossed every second.

Stores can treat a non-positive TTL as a delete, which is what the Laravel cache store does. So `set()` returns `false` when the key had not been written yet, and `save()` throws `LimitException` with "The store was unable to update the limit". When the key already existed, `set()` returns `true` after wiping the counter.

We caught it as a CI flake that went green on a plain re-run, and aligning `save()` to the second boundary locally reproduces it in 1 of 200 attempts.

Clamping the TTL to a minimum of 1 second is safe because `update()` already ignores data whose `timestamp` has passed. The test ticks `getCurrentTimestamp()` once between the two reads, so it reproduces the race deterministically and fails on `v2` without the fix.